### PR TITLE
Запрет масштабирования окна

### DIFF
--- a/instead-manager-tk.pyw
+++ b/instead-manager-tk.pyw
@@ -181,6 +181,7 @@ if __name__ == "__main__":
     instead_manager_tk = InsteadManagerTk(instead_manager)
 
     root = Tk(className='INSTEAD Manager')
+    root.resizable(width=FALSE, height=FALSE)
 
     # ttk theme for UNIX-like systems
     if InsteadManagerHelper.is_unix():


### PR DESCRIPTION
Окно приложения в Linux можно масштабировать, но поскольку элементы интерфейса не меняют свой размер, результат выглядит не очень.
Предлагаю заблокировать изменение размера окна.
